### PR TITLE
Fix | OLC-267 | PDF Image Upload Shows Blank in Template Builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openlettermarketing/olc-react-sdk",
   "private": false,
-  "version": "1.5.4",
+  "version": "1.5.5",
   "type": "module",
   "description": "Simplify template builder integration for any product.",
   "main": "build/index.js",

--- a/src/components/TemplateBuilder/index.tsx
+++ b/src/components/TemplateBuilder/index.tsx
@@ -25,7 +25,7 @@ import { failure } from '../../redux/actions/snackbarActions';
 // Utils
 import { drawRestrictedAreaOnPage, getFileAsBlob } from '../../utils/template-builder';
 import { addElementsforRealPennedLetters } from '../../utils/templateRestrictedArea/realPenned';
-import { DPI, multiPageLetters } from '../../utils/constants';
+import { DPI, allowedImageTypes, multiPageLetters } from '../../utils/constants';
 
 // @ts-ignore
 import fonts from "../../utils/fonts.json";
@@ -43,7 +43,6 @@ import './styles.scss';
 // utils
 import {MESSAGES} from '../../utils/message';
 
-setUploadFunc(uploadFile)
 /**
  * This code defines a React functional component called `TemplateBuilder` that is responsible for rendering a template builder interface.
  * It includes various useEffect hooks to handle component lifecycle events and state updates.
@@ -134,6 +133,7 @@ const TemplateBuilder: React.FC<TemplateBuilderProps> = ({ store, onReturnAndNav
   // @ts-ignore
   useEffect(() => {
     if (product || (id && onGetOneTemplate)) {
+      setUploadFunc(validateFile);
       setGoogleFonts(fonts);
 
       if (id && onGetOneTemplate) {
@@ -217,6 +217,14 @@ const TemplateBuilder: React.FC<TemplateBuilderProps> = ({ store, onReturnAndNav
         })
       }
     }
+  }
+
+  const validateFile = (file: File) => {
+    if (!file || !allowedImageTypes.includes(file?.type)) {
+      dispatch(failure('Only image files with extensions jpeg, png, or svg are allowed.'))
+      return;
+    } 
+    return uploadFile(file);
   }
 
   const createInitialPage = async () => {

--- a/src/components/TemplateBuilder/index.tsx
+++ b/src/components/TemplateBuilder/index.tsx
@@ -222,7 +222,7 @@ const TemplateBuilder: React.FC<TemplateBuilderProps> = ({ store, onReturnAndNav
   const validateFile = (file: File) => {
     if (!file || !allowedImageTypes.includes(file?.type)) {
       dispatch(failure('Only image files with extensions jpeg, png, or svg are allowed.'))
-      return;
+      throw new Error('Unsupported type');
     } 
     return uploadFile(file);
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,6 +20,8 @@ export const multiPageLetters: string[] = [
 //@ts-ignore
 export const emojiRegex = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F700}-\u{1F77F}]|[\u{1F780}-\u{1F7FF}]|[\u{1F800}-\u{1F8FF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|[\u{2300}-\u{23FF}]|[\u{2B50}\u{2B55}]|[\u{1F004}\u{1F0CF}]/u;
 
+export const allowedImageTypes = ['image/jpeg', 'image/png', 'image/svg+xml'];
+
 interface TemplateTypes {
   id: string;
   label: string;


### PR DESCRIPTION
Added functionality to validate the file type before uploading

Jira: https://openletterconnect.atlassian.net/jira/software/c/projects/OLC/boards/5?assignee=712020%3Aac91928a-81ba-4d9e-b07c-36c0e80acade&selectedIssue=OLC-267