### PR TITLE
Fix | OLC-406 | Fixed: Hand Icon Not Displayed When Hovering Over Add-on Section

### DIFF
--- a/src/components/SidePanel/CustomAddOns/styles.scss
+++ b/src/components/SidePanel/CustomAddOns/styles.scss
@@ -21,6 +21,7 @@
     align-items: center;
     flex-direction: column;
     margin-bottom: 10px;
+    cursor: pointer;
     p {
       font-size: 16px;
       font-style: normal;


### PR DESCRIPTION
https://openletterconnect.atlassian.net/browse/OLC-406