### PR TITLE
Fix | OLC-1084 | Valid YouTube video URL incorrectly marked as invalid in Custom Design Form

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -61,8 +61,7 @@ export const sortOrderForTemplates: string[] = [
 ];
 
 export const EMAIL_REGEX = /^[a-z0-9](\.?[a-z0-9_\-\+])*@[a-z0-9](\.?[a-z0-9-])*\.[a-z]{2,}$/i;
-export const VIDEO_URL_REGEX = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([\/\w .-]*)*\/?(\?[\w=&]*)?$/;
-
+export const VIDEO_URL_REGEX = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
 
 export const DISALLOWED_DOMAINS = [
   'qrforward.org',


### PR DESCRIPTION
https://openletterconnect.atlassian.net/jira/software/c/projects/OLC/boards/5?assignee=712020%3Aac91928a-81ba-4d9e-b07c-36c0e80acade&selectedIssue=OLC-1084